### PR TITLE
#53 unnecessary escape

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -648,7 +648,7 @@ components:
           type: string
         article_id:
           type: string
-          pattern: "[A-Za-z0-9_\-]+"
+          pattern: "[A-Za-z0-9_-]+"
         author:
           type: object
           readOnly: true


### PR DESCRIPTION
fix: #53 
`[]` の 冒頭or末尾のときはescapeが要らないらしいです ふーん