### PR TITLE
#175 draft_id を Exhibition に含めた

### DIFF
--- a/src/apis/online/exhibition/@types.ts
+++ b/src/apis/online/exhibition/@types.ts
@@ -4,6 +4,7 @@ export interface Exhibition {
   type: ExhibitionType;
   thumbnail_image_id: string;
   content: string | null;
+  draft_id: number | null;
   updated_at: string;
 }
 


### PR DESCRIPTION
close #175 

ちなみに BlogArticle には revision_id が含まれてます そのへんも踏まえての追加判断

```ts
export interface BlogArticle {
  // ...
  revision_id: number;
  // ...
}

```