### PR TITLE
#201 ColorId 型を再定義・term.color_id にも型を付与 [v2.2.19]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afes-website/docs",
-  "version": "2.2.18",
+  "version": "2.2.19",
   "description": "73rd Afes website API",
   "license": "MIT",
   "repository": {

--- a/src/apis/onsite/general/guest/@types.ts
+++ b/src/apis/onsite/general/guest/@types.ts
@@ -1,20 +1,8 @@
-const colors = [
-  "blue",
-  "red",
-  "yellow",
-  "violet",
-  "orange",
-  "green",
-  "gray",
-  "white",
-  "test_blue",
-  "test_red",
-  "test_yellow",
-] as const;
+import { ColorId } from "../term/@types";
 
 export interface Guest {
   id: string;
-  color_id: typeof colors[number];
+  color_id: ColorId;
   term_id: string;
   entered_at: string;
   exit_scheduled_time: string | null;

--- a/src/apis/onsite/general/guest/@types.ts
+++ b/src/apis/onsite/general/guest/@types.ts
@@ -1,13 +1,11 @@
-import { ColorId } from "../term/@types";
+import { Term } from "../term/@types";
 
 export interface Guest {
   id: string;
-  color_id: ColorId;
-  term_id: string;
   entered_at: string;
-  exit_scheduled_time: string | null;
   exited_at: string | null;
   exh_id: string | null;
+  term: Term;
 }
 
-export type GuestSummary = Pick<Guest, "id" | "color_id" | "term_id">;
+export type GuestSummary = Pick<Guest, "id" | "term">;

--- a/src/apis/onsite/general/term/@types.ts
+++ b/src/apis/onsite/general/term/@types.ts
@@ -15,11 +15,12 @@ const colorIdList = [
 export type ColorId = typeof colorIdList[number];
 
 export interface Term {
+  id: string;
   enter_scheduled_time: string;
   exit_scheduled_time: string;
   color_id: ColorId;
 }
 
 export interface Terms {
-  [term_id: string]: Term;
+  [term_id: string]: Omit<Term, "id">;
 }

--- a/src/apis/onsite/general/term/@types.ts
+++ b/src/apis/onsite/general/term/@types.ts
@@ -22,5 +22,5 @@ export interface Term {
 }
 
 export interface Terms {
-  [term_id: string]: Omit<Term, "id">;
+  [term_id: string]: Term;
 }

--- a/src/apis/onsite/general/term/@types.ts
+++ b/src/apis/onsite/general/term/@types.ts
@@ -1,7 +1,23 @@
+const colorIdList = [
+  "GB",
+  "GR",
+  "GY",
+  "GV",
+  "GO",
+  "GG",
+  "GW",
+  "SG",
+  "TB",
+  "TR",
+  "TY",
+] as const;
+
+export type ColorId = typeof colorIdList[number];
+
 export interface Term {
   enter_scheduled_time: string;
   exit_scheduled_time: string;
-  color_id: string;
+  color_id: ColorId;
 }
 
 export interface Terms {

--- a/src/apis/onsite/general/term/@types.ts
+++ b/src/apis/onsite/general/term/@types.ts
@@ -1,4 +1,4 @@
-const colorIdList = [
+export const guestIdPrefixList = [
   "GB",
   "GR",
   "GY",
@@ -12,13 +12,13 @@ const colorIdList = [
   "TY",
 ] as const;
 
-export type ColorId = typeof colorIdList[number];
+export type GuestIdPrefix = typeof guestIdPrefixList[number];
 
 export interface Term {
   id: string;
   enter_scheduled_time: string;
   exit_scheduled_time: string;
-  color_id: ColorId;
+  prefix: GuestIdPrefix;
 }
 
 export interface Terms {


### PR DESCRIPTION
fix #201

別名である必要が無いので、Guest Id の prefix と統一しました
