### PR TITLE
#210 alpha 版の publish に対応

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,3 +27,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: publish
         run: npm publish --access public
+        if: !contains(github.ref, "alpha")
+      - name: publish as alpha
+        run: npm publish --access public --tag alpha
+        if: contains(github.ref, "alpha")


### PR DESCRIPTION
close #210

> `github.ref` `string` ワークフローの実行をトリガーしたブランチまたはタグ ref。 ブランチの場合、これは refs/heads/<branch_name> の形式で、タグの場合は refs/tags/<tag_name> です。

あってるか自信がないです
