### PR TITLE
#212･#213 展示が存在しない場合・responseを統一

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afes-website/docs",
-  "version": "2.2.22",
+  "version": "2.3.0-alpha.0",
   "description": "73rd Afes website API",
   "license": "MIT",
   "repository": {

--- a/src/apis/onsite/exhibition/enter/index.ts
+++ b/src/apis/onsite/exhibition/enter/index.ts
@@ -19,6 +19,7 @@ export interface Methods {
    * | `PEOPLE_LIMIT_EXCEEDED` | 人数制限に達した                             |
    * | `GUEST_ALREADY_EXITED`  | すでに退場済みである                         |
    * | `EXIT_TIME_EXCEEDED`    | 退場予定時刻を過ぎている                     |
+   * | `EXHIBITION_NOT_FOUND`  | 該当する展示が存在しない                     |
    *
    * @returns 来場者に関する情報
    */

--- a/src/apis/onsite/exhibition/exit/index.ts
+++ b/src/apis/onsite/exhibition/exit/index.ts
@@ -16,6 +16,7 @@ export interface Methods {
    * | :--------------------- | :-------------------------- |
    * | `GUEST_NOT_FOUND`      | 該当する Guest が存在しない |
    * | `GUEST_ALREADY_EXITED` | すでに退場済みである        |
+   * | `EXHIBITION_NOT_FOUND` | 該当する展示が存在しない    |
    *
    * @returns 来場者に関する情報
    */

--- a/src/apis/onsite/exhibition/log/index.ts
+++ b/src/apis/onsite/exhibition/log/index.ts
@@ -9,6 +9,9 @@ export interface Methods {
    * 必要な権限:
    * - exhibition
    *
+   * @throws Error
+   * 404: 該当する展示が存在しない
+   *
    * @returns 展示に関係する行動ログのリスト
    */
   get: {

--- a/src/apis/onsite/general/exit/index.ts
+++ b/src/apis/onsite/general/exit/index.ts
@@ -10,8 +10,12 @@ export interface Methods {
    * - general
    *
    * @throws Error
-   * 404: ID に該当する Guest が存在しない
-   * 409: 該当する Guest はすでに退場済み
+   * 400: response Body に必ず status_code が 1 つ含まれる。複数該当する場合はどれか 1 つが返される。
+   * 対応表は以下
+   * | status_code            | Explanation                 |
+   * | :--------------------- | :-------------------------- |
+   * | `GUEST_NOT_FOUND`      | 該当する Guest が存在しない |
+   * | `GUEST_ALREADY_EXITED` | すでに退場済みである        |
    *
    * @returns 来場者に関する情報
    */


### PR DESCRIPTION
close #212
close #213

- fix: response status code at general/exit
- fix: add EXHIBITION_NOT_FOUND
- fix: add 404 to exhibition/log
- v2.3.0-alpha.0
