### PR TITLE
#245 ExhとExhibitionを統一した

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afes-website/docs",
-  "version": "3.0.0-alpha.13",
+  "version": "3.0.0-alpha.14",
   "description": "73rd Afes website API",
   "license": "MIT",
   "repository": {

--- a/src/apis/exhibitions/@types.ts
+++ b/src/apis/exhibitions/@types.ts
@@ -19,7 +19,7 @@ export interface ExhibitionStatus {
 }
 
 export interface AllStatus {
-  exh: {
+  exhibition: {
     [exhibition_id: string]: ExhibitionStatus;
   };
   all: Pick<ExhibitionStatus, "count" | "capacity">;

--- a/src/apis/exhibitions/@types.ts
+++ b/src/apis/exhibitions/@types.ts
@@ -1,4 +1,4 @@
-export interface ExhStatus {
+export interface ExhibitionStatus {
   info: {
     room_id: string;
     name: string;
@@ -20,7 +20,7 @@ export interface ExhStatus {
 
 export interface AllStatus {
   exh: {
-    [exhibition_id: string]: ExhStatus;
+    [exhibition_id: string]: ExhibitionStatus;
   };
-  all: Pick<ExhStatus, "count" | "capacity">;
+  all: Pick<ExhibitionStatus, "count" | "capacity">;
 }

--- a/src/apis/exhibitions/@types.ts
+++ b/src/apis/exhibitions/@types.ts
@@ -20,7 +20,7 @@ export interface ExhStatus {
 
 export interface AllStatus {
   exh: {
-    [exh_id: string]: ExhStatus;
+    [exhibition_id: string]: ExhStatus;
   };
   all: Pick<ExhStatus, "count" | "capacity">;
 }

--- a/src/apis/exhibitions/_id@string/index.ts
+++ b/src/apis/exhibitions/_id@string/index.ts
@@ -1,5 +1,5 @@
 import { AuthToken } from "../../@types";
-import { ExhStatus } from "../@types";
+import { ExhibitionStatus } from "../@types";
 
 export interface Methods {
   /**
@@ -17,6 +17,6 @@ export interface Methods {
    */
   get: {
     reqHeaders: AuthToken;
-    resBody: ExhStatus;
+    resBody: ExhibitionStatus;
   };
 }

--- a/src/apis/guests/@types.ts
+++ b/src/apis/guests/@types.ts
@@ -4,7 +4,7 @@ export interface Guest {
   id: string;
   entered_at: string;
   exited_at: string | null;
-  exh_id: string | null;
+  exhibition_id: string | null;
   term: Term;
 }
 

--- a/src/apis/log/@types.ts
+++ b/src/apis/log/@types.ts
@@ -4,7 +4,7 @@ export interface ActivityLog {
   id: string;
   timestamp: string;
   guest: GuestSummary;
-  exh_id: string;
+  exhibition_id: string;
   log_type: ActivityLogType;
 }
 


### PR DESCRIPTION
resolve: #245

修正してたら他に Exh 使ってるの ExhStatus だけだったので、ついでにそこも一緒にしました こっちは完全なリファクタリングで影響はないと思うけど問題があったら言ってください
- chore: rename exh_id to exhibition_id
- refacotr: ExhStatus -> ExhibitionStatus
- v3.0.0-alpha.14
