### PR TITLE
#249 各展示への滞在状況を公開する

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afes-website/docs",
-  "version": "3.0.0-alpha.18",
+  "version": "3.0.0-alpha.19",
   "description": "73rd Afes website API",
   "license": "MIT",
   "repository": {

--- a/src/apis/exhibitions/_id@string/index.ts
+++ b/src/apis/exhibitions/_id@string/index.ts
@@ -5,11 +5,6 @@ export interface Methods {
   /**
    * 展示の情報の取得
    *
-   * @remarks
-   * 必要な権限:
-   * - exhibition
-   * - executive
-   *
    * @throws Error
    * 404: 該当する展示が存在しない
    *

--- a/src/apis/exhibitions/index.ts
+++ b/src/apis/exhibitions/index.ts
@@ -5,11 +5,6 @@ export interface Methods {
   /**
    * 全展示・校内の情報の取得
    *
-   * @remarks
-   * 必要な権限:
-   * - executive
-   * - exhibition
-   *
    * @returns 各展示・校内の情報と滞在状況
    */
   get: {


### PR DESCRIPTION
close #249

> 各展示へのリアルタイム滞在状況は、全展示員が閲覧できます。滞在状況を公開し、ヒートマップ公開など混雑緩和に使用する構想もあります。
匿名化された個人の展示滞在履歴は、統制局員・運営局員のみが閲覧できます。
[個人情報の考え方](https://www.notion.so/su8ru/5302a40228374486b6da4ec1703cd0b6)